### PR TITLE
Make `git diff` ignore `pubspec.lock` changes

### DIFF
--- a/lib/src/impl.dart
+++ b/lib/src/impl.dart
@@ -59,7 +59,7 @@ void expectResultOutputSucceeds(String result) {
 }
 
 Future<String> _changedGeneratedFiles(String workingDir) =>
-    _runProc('git', ['diff'], workingDir);
+    _runProc('git', ['diff', ':!pubspec.lock'], workingDir);
 
 Future<String> _runProc(
   String proc,


### PR DESCRIPTION
The `build_verify` test usually works in a CI, just after a `dart pub get` and usually in a different OS from the developer computer (the `pubspec.lock` committer). It is not possible to guarantee that a `pubspec.lock` will not be altered in this common use case.