### PR TITLE
Fix diff command when running in nested directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 3.0.1-dev
+## 3.0.1
 
+- Run `git diff` only on the current working directory.
 - Require Dart >= 2.17.0
 
 ## 3.0.0

--- a/lib/src/impl.dart
+++ b/lib/src/impl.dart
@@ -59,7 +59,7 @@ void expectResultOutputSucceeds(String result) {
 }
 
 Future<String> _changedGeneratedFiles(String workingDir) =>
-    _runProc('git', ['diff'], workingDir);
+    _runProc('git', ['diff', '.'], workingDir);
 
 Future<String> _runProc(
   String proc,

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '3.0.1-dev';
+const packageVersion = '3.0.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: build_verify
 description: >-
   Test utility to ensure generated Dart code within a package is up-to-date
   when using package:build.
-version: 3.0.1-dev
+version: 3.0.1
 repository: https://github.com/kevmoo/build_verify
 
 environment:

--- a/test/integration/helpers.dart
+++ b/test/integration/helpers.dart
@@ -1,0 +1,23 @@
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+d.FileDescriptor getPubspecYamlFile(String packageName) => d.file(
+      'pubspec.yaml',
+      '''
+name: $packageName
+version: 1.2.3
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dev_dependencies:
+  build_runner: ^2.0.0
+  build_version: ^2.0.0
+''',
+    );
+
+d.FileDescriptor getGeneratedVersionFile(String version) => d.file(
+      'version.dart',
+      '''
+// Generated code. Do not modify.
+const packageVersion = '$version';
+''',
+    );

--- a/test/integration/nested_integration_test.dart
+++ b/test/integration/nested_integration_test.dart
@@ -1,0 +1,99 @@
+@Timeout.factor(4)
+
+import 'package:build_verify/build_verify.dart' show defaultCommand;
+import 'package:build_verify/src/impl.dart';
+import 'package:build_verify/src/utils.dart';
+import 'package:git/git.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+import 'package:test_process/test_process.dart';
+
+import 'helpers.dart';
+
+void main() {
+  setUp(() async {
+    await d.dir('package_a', [
+      getPubspecYamlFile('package_a'),
+      d.dir('lib', [
+        d.dir('src', [
+          getGeneratedVersionFile('1.2.3'),
+        ])
+      ])
+    ]).create();
+
+    await d.dir('package_b', [
+      getPubspecYamlFile('package_b'),
+      d.dir('lib', [
+        d.dir('src', [
+          getGeneratedVersionFile('1.2.3'),
+        ])
+      ])
+    ]).create();
+
+    final gitDir = await GitDir.init(d.sandbox, allowContent: true);
+    await gitDir.runCommand(['add', '.']);
+    await gitDir.runCommand(['commit', '-am', 'test']);
+
+    final packageAProcess = await TestProcess.start(
+      dartPath,
+      ['pub', 'get'],
+      workingDirectory: '${d.sandbox}/package_a',
+    );
+
+    await packageAProcess.shouldExit(0);
+
+    final packageBProcess = await TestProcess.start(
+      dartPath,
+      ['pub', 'get'],
+      workingDirectory: '${d.sandbox}/package_b',
+    );
+
+    await packageBProcess.shouldExit(0);
+  });
+
+  test(
+    'when they have no modification, package a and b tests should pass',
+    () async {
+      await expectBuildCleanImpl(
+        '${d.sandbox}/package_a',
+        defaultCommand,
+        packageRelativeDirectory: 'package_a',
+      );
+      await expectBuildCleanImpl(
+        '${d.sandbox}/package_b',
+        defaultCommand,
+        packageRelativeDirectory: 'package_b',
+      );
+    },
+  );
+
+  test(
+    '''when package b has modifications,
+      package a test should pass and package b test should fail''',
+    () async {
+      await d.dir('package_b', [
+        getPubspecYamlFile('package_b'),
+        d.dir('lib', [
+          d.dir('src', [
+            getGeneratedVersionFile('1.2.4'),
+          ])
+        ])
+      ]).create();
+
+      await expectBuildCleanImpl(
+        '${d.sandbox}/package_a',
+        defaultCommand,
+        packageRelativeDirectory: 'package_a',
+      );
+
+      expect(
+        () => expectBuildCleanImpl(
+          '${d.sandbox}/package_b',
+          defaultCommand,
+          packageRelativeDirectory: 'package_b',
+        ),
+        throwsA(const TypeMatcher<TestFailure>()),
+      );
+    },
+  );
+}

--- a/test/integration/simple_integration_test.dart
+++ b/test/integration/simple_integration_test.dart
@@ -8,31 +8,15 @@ import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
 
+import 'helpers.dart';
+
 void main() {
   setUp(() async {
-    await d.file(
-      'pubspec.yaml',
-      '''
-name: example
-version: 1.2.3
-environment:
-  sdk: '>=2.12.0 <3.0.0'
-
-dev_dependencies:
-  build_runner: ^2.0.0
-  build_version: ^2.0.0
-''',
-    ).create();
+    await getPubspecYamlFile('example').create();
 
     await d.dir('lib', [
       d.dir('src', [
-        d.file(
-          'version.dart',
-          r'''
-// Generated code. Do not modify.
-const packageVersion = '1.2.3';
-''',
-        )
+        getGeneratedVersionFile('1.2.3'),
       ])
     ]).create();
 


### PR DESCRIPTION
I noticed that my tests were:
- failing when running in parallel (with melos)
- but passing when running independently or sequentially.

This is due to the diffing command being applied to the whole directory, and not just to the current `workingDir`. So if I have package `a` and package `b`, a diff in package `b` (due to a file being regenerated) will cause package `a` to notice a diff and fail the test, even if its own directory doesn't have any diff.

This PR makes sure that the diff is computed only for the current working directory, which enables tests using this package to run in parallel inside monorepos.