### PR TITLE
blast repo changes: dependabot, github-actions, no-response

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       interval: monthly
     labels:
       - autosubmit
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       matrix:
         sdk: [dev]
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
-      - uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: ${{ matrix.sdk }}
       - id: install
@@ -44,8 +44,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         sdk: [3.4, dev]
     steps:
-    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
-    - uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+    - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
       with:
         sdk: ${{ matrix.sdk }}
     - id: install
@@ -67,7 +67,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         flutter-channel: [stable]
     steps:
-    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
     - uses: subosito/flutter-action@44ac965b96f18d999802d4b807e3256d5a3f9fa1
       with:
         channel: ${{ matrix.flutter-channel }}


### PR DESCRIPTION
This PR contains changes created by the blast repo tool.

- `dependabot`
- `github-actions`
- `no-response`