### PR TITLE
test: migrate test suite to package:checks

### DIFF
--- a/lib/src/impl.dart
+++ b/lib/src/impl.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:checks/checks.dart';
 import 'package:io/ansi.dart' as ansi;
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
 
 import '../build_verify.dart';
 import 'utils.dart';
@@ -33,14 +33,13 @@ Future<void> expectBuildCleanImpl(
   }
 
   // 1 - get a list of modified files files - should be empty
-  expect(
+  check(
     await _changedGeneratedFiles(
       workingDir,
       gitDiffPathArguments: gitDiffPathArguments,
     ),
-    isEmpty,
-    reason: 'The working directory should be clean before running build.',
-  );
+    because: 'The working directory should be clean before running build.',
+  ).isEmpty();
 
   var executable = command.first;
   if (executable == 'DART') {
@@ -55,23 +54,20 @@ Future<void> expectBuildCleanImpl(
   expectResultOutputSucceeds(result);
 
   // 3 - get a list of modified files after the build - should still be empty
-  expect(
+  check(
     await _changedGeneratedFiles(
       workingDir,
       gitDiffPathArguments: gitDiffPathArguments,
     ),
-    isEmpty,
-  );
+  ).isEmpty();
 }
 
 void expectResultOutputSucceeds(String result) {
-  expect(
-    result,
-    anyOf(
-      contains('Built with build_runner'),
-      contains(RegExp(r'\[INFO\] Succeeded after .+ with \d+ outputs')),
-    ),
-  );
+  check(result).anyOf([
+    (it) => it.contains('Built with build_runner'),
+    (it) =>
+        it.contains(RegExp(r'\[INFO\] Succeeded after .+ with \d+ outputs')),
+  ]);
 }
 
 Future<String> _changedGeneratedFiles(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
+  checks: ^0.3.1
   io: ^1.0.0
   path: ^1.9.0
   test: ^1.25.9

--- a/test/ensure_build_test.dart
+++ b/test/ensure_build_test.dart
@@ -2,7 +2,7 @@
 library;
 
 import 'package:build_verify/build_verify.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   test('ensure_build', expectBuildClean, timeout: const Timeout.factor(2));

--- a/test/integration/nested_integration_test.dart
+++ b/test/integration/nested_integration_test.dart
@@ -3,12 +3,12 @@ library;
 
 import 'package:build_verify/src/impl.dart';
 import 'package:build_verify/src/utils.dart';
+import 'package:checks/checks.dart';
 import 'package:git/git.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
 
-import '../test_shared.dart';
 import 'helpers.dart';
 
 void main() {
@@ -76,13 +76,12 @@ void main() {
         packageRelativeDirectory: 'package_a',
       );
 
-      expect(
-        () => expectBuildCleanImpl(
+      await check(
+        expectBuildCleanImpl(
           '${d.sandbox}/package_b',
           packageRelativeDirectory: 'package_b',
         ),
-        throwsATestFailure,
-      );
+      ).throws<TestFailure>();
     },
   );
 }

--- a/test/integration/simple_integration_test.dart
+++ b/test/integration/simple_integration_test.dart
@@ -5,12 +5,12 @@ import 'dart:io';
 
 import 'package:build_verify/src/impl.dart';
 import 'package:build_verify/src/utils.dart';
+import 'package:checks/checks.dart';
 import 'package:git/git.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
 
-import '../test_shared.dart';
 import 'helpers.dart';
 
 void main() {
@@ -52,7 +52,7 @@ void main() {
       await sink.close();
     });
     test('should fail', () async {
-      await expectLater(expectBuildCleanImpl(d.sandbox), throwsATestFailure);
+      await check(expectBuildCleanImpl(d.sandbox)).throws<TestFailure>();
     });
     test('should not fail if ignored', () async {
       await expectBuildCleanImpl(

--- a/test/success_parse_test.dart
+++ b/test/success_parse_test.dart
@@ -1,7 +1,6 @@
 import 'package:build_verify/src/impl.dart';
+import 'package:checks/checks.dart';
 import 'package:test/test.dart';
-
-import 'test_shared.dart';
 
 void main() {
   for (var duration in [
@@ -20,7 +19,7 @@ void main() {
     test('failing output with ${_humanReadable(duration)}', () {
       final output = '[INFO] Failed after ${_humanReadable(duration)}';
 
-      expect(() => expectResultOutputSucceeds(output), throwsATestFailure);
+      check(() => expectResultOutputSucceeds(output)).throws<TestFailure>();
     });
   }
 }

--- a/test/test_shared.dart
+++ b/test/test_shared.dart
@@ -1,9 +1,0 @@
-import 'package:test/test.dart';
-
-final throwsATestFailure = throwsA(
-  const TypeMatcher<TestFailure>().having(
-    (p0) => p0.message,
-    'message',
-    isNotEmpty,
-  ),
-);


### PR DESCRIPTION
Migrates the test suite from `package:matcher` to `package:checks`.

Verified 100% clean static analysis (`dart analyze`) and all tests passing (`dart test`).