### PR TITLE
fix(analysis): add platform exclusions to analysis_options.yaml

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,14 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   language:
     strict-casts: true
 


### PR DESCRIPTION
Adds default platform directory exclusions to analysis_options.yaml to prevent Flutter ProjectMigrator from mutating the file during test runs.