### PR TITLE
refactor: migrate dart executable lookup to package:cli_util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.1.2-wip
 
+- Migrate `dart` executable lookup to `package:cli_util` (`dartExecutable ?? 'dart'`).
 - Require `sdk: ^3.10.0`
 
 ## 3.1.1

--- a/lib/build_verify.dart
+++ b/lib/build_verify.dart
@@ -16,9 +16,9 @@ const defaultCommand = [
 /// The first item in [customCommand] is used as the executable to run. The
 /// remaining values are used as the executable arguments.
 ///
-/// If the first value is `PUB` or `DART` (case-sensitive), it will be replaced
-/// with the full, platform-specific path to the corresponding executable in the
-/// currently executing SDK.
+/// If the first value is `DART` (case-sensitive), it will be replaced
+/// with the path to the `dart` executable in the current SDK (or `'dart'`
+/// if no SDK path could be resolved).
 ///
 /// If provided, [gitDiffPathArguments] are passed as `-- <path>` to `git diff`.
 /// This can be useful if you want to include certain files from the diff

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,21 +1,4 @@
-import 'dart:io';
+import 'package:cli_util/cli_util.dart';
 
-import 'package:path/path.dart' as p;
-
-/// The path to the root directory of the SDK.
-final String dartPath = (() {
-  final executableBaseName = p.basename(Platform.resolvedExecutable);
-
-  if (executableBaseName == 'flutter_tester' ||
-      executableBaseName == 'flutter_tester.exe') {
-    final flutterRoot = Platform.environment['FLUTTER_ROOT']!;
-
-    return p.join(flutterRoot, 'bin', 'cache', 'dart-sdk', 'bin', 'dart');
-  } else {
-    assert(
-      executableBaseName == 'dart' || executableBaseName == 'dart.exe',
-      'Was not expected "$executableBaseName".',
-    );
-    return Platform.resolvedExecutable;
-  }
-})();
+/// The path to the `dart` executable.
+final String dartPath = dartExecutable ?? 'dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   checks: ^0.3.1
+  cli_util: ^0.6.0
   io: ^1.0.0
   path: ^1.9.0
   test: ^1.25.9


### PR DESCRIPTION
- Replace manual Platform.resolvedExecutable / FLUTTER_ROOT! logic in lib/src/utils.dart with package:cli_util (dartExecutable ?? 'dart').
- Add cli_util: ^0.6.0 dependency to pubspec.yaml and update CHANGELOG.md.
